### PR TITLE
Use image file name based in input URL

### DIFF
--- a/dietpi-install.sh
+++ b/dietpi-install.sh
@@ -1,38 +1,40 @@
 #!/bin/bash
 
 # Variables
-IMAGE_URL=$(whiptail --inputbox "Enter the URL for the DietPi image (default: https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Bullseye.7z):" 8 78 https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Bullseye.7z --title "DietPi Installation" 3>&1 1>&2 2>&3)
-RAM=$(whiptail --inputbox "Enter the amount of RAM (in MB) for the new virtual machine (default: 2048):" 8 78 2048 --title "DietPi Installation" 3>&1 1>&2 2>&3)
-CORES=$(whiptail --inputbox "Enter the number of cores for the new virtual machine (default: 2):" 8 78 2 --title "DietPi Installation" 3>&1 1>&2 2>&3)
+IMAGE_URL=$(whiptail --inputbox 'Enter the URL for the DietPi image (default: https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Bullseye.7z):' 8 78 'https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Bullseye.7z' --title 'DietPi Installation' 3>&1 1>&2 2>&3)
+RAM=$(whiptail --inputbox 'Enter the amount of RAM (in MB) for the new virtual machine (default: 2048):' 8 78 2048 --title 'DietPi Installation' 3>&1 1>&2 2>&3)
+CORES=$(whiptail --inputbox 'Enter the number of cores for the new virtual machine (default: 2):' 8 78 2 --title 'DietPi Installation' 3>&1 1>&2 2>&3)
 
 # Get the next available VMID
 ID=$(pvesh get /cluster/nextid)
 
-touch /etc/pve/qemu-server/$ID.conf
+touch "/etc/pve/qemu-server/$ID.conf"
 
 # Get the storage name from the user
-STORAGE=$(whiptail --inputbox "Enter the storage name where the image should be imported:" 8 78 --title "DietPi Installation" 3>&1 1>&2 2>&3)
+STORAGE=$(whiptail --inputbox 'Enter the storage name where the image should be imported:' 8 78 --title 'DietPi Installation' 3>&1 1>&2 2>&3)
 
 # Download DietPi image
-wget $IMAGE_URL
+wget "$IMAGE_URL"
 
 # Extract the image
-7zr x DietPi_Proxmox-x86_64-Bullseye.7z
+IMAGE_NAME=${IMAGE_URL##*/}
+IMAGE_NAME=${IMAGE_NAME%.7z}
+7zr e "$FILE_NAME.7z" "$FILE_NAME.qcow2"
 sleep 3
 
 # import the qcow2 file to the default virtual machine storage
-qm importdisk $ID DietPi_Proxmox-x86_64-Bullseye.qcow2 $STORAGE
+qm importdisk "$ID" "$FILE_NAME.qcow2" "$STORAGE"
 
 # Set vm settings
-qm set $ID --cores "$CORES"
-qm set $ID --memory "$RAM"
-qm set $ID --net0 "virtio,bridge=vmbr0"
-qm set $ID --scsi0 "$STORAGE:vm-$ID-disk-0"
-qm set $ID --boot order='scsi0'
-qm set $ID --scsihw virtio-scsi-pci
+qm set "$ID" --cores "$CORES"
+qm set "$ID" --memory "$RAM"
+qm set "$ID" --net0 'virtio,bridge=vmbr0'
+qm set "$ID" --scsi0 "$STORAGE:vm-$ID-disk-0"
+qm set "$ID" --boot order='scsi0'
+qm set "$ID" --scsihw virtio-scsi-pci
 
 # Tell user the virtual machine is created
 echo "VM $ID Created."
 
 # Start the virtual machine
-qm start $ID
+qm start "$ID"


### PR DESCRIPTION
While the URL can be changed, the file name was hardcoded, which can fail if e.g. the Bookworm image is downloaded, or prospectively an ARM VM image. This commit obtains the image file name based on the download URL, removing all path elements up to the file name.

Furthermore, only the qcow2 file is extracted, skipping README and hashes.

Other changes for applying best practice shell code:
- All command arguments with variables are double-quoted, to avoid potential word splitting and globbing. None of them should contain spaces, but it they are input accidentally, this prevents unexpected and possibly faulty/dangerous actions by the commands and gives better error messages, like "file 'foo bar' does not exist".
- Quotation of strings, which do not contain any variable, are changed to single quotes. This assures that no unexpected shell expansion is done. The previously double-quoted strings are safe to be double-quoted now, but this is a precaution for future development and contributions of others who might not know about all ways of shell expansions inside strings.

Please test once before merging. I didn't do it yet 😉!