### PR TITLE
Update dietpi-install.sh

### DIFF
--- a/dietpi-install.sh
+++ b/dietpi-install.sh
@@ -16,19 +16,6 @@ touch "/etc/pve/qemu-server/$ID.conf"
 # Get the storage name from the user
 STORAGE=$(whiptail --inputbox 'Enter the storage name where the image should be imported:' 8 78 --title 'DietPi Installation' 3>&1 1>&2 2>&3)
 
-# Ask if user what filesystem they are installing the VM on. BTRFS, ZFS, Directory OR LVM-Thin Provisioning.
-if (whiptail --title "What filesystem are you installing the VM on?" --yesno $"If using BTRFS, ZFS or Directory storage? Select YES \n                       \nIf using LVM-Thin Provisioning? Select NO" 10 78); then
-    use_btrfs="y"
-else
-    use_btrfs="n"
-fi
-
-if [ "$use_btrfs" = "y" ]; then
-  qm_disk_param="$STORAGE:$ID/vm-$ID-disk-0.raw"
-else
-  qm_disk_param="$STORAGE:vm-$ID-disk-0"  
-fi
-
 # Download DietPi image
 wget "$IMAGE_URL"
 
@@ -38,20 +25,20 @@ xz -d "$IMAGE_NAME"
 IMAGE_NAME=${IMAGE_NAME%.xz}
 sleep 3
 
-# import the qcow2 file to the default virtual machine storage
+# Import the qcow2 file to the default virtual machine storage
 qm importdisk "$ID" "$IMAGE_NAME" "$STORAGE"
 
 # Set vm settings
 qm set "$ID" --cores "$CORES"
 qm set "$ID" --memory "$RAM"
-qm set "$ID" --net0 'virtio,bridge=vmbr0'
-qm set "$ID" --scsi0 "$qm_disk_param"
-qm set "$ID" --boot order='scsi0'
 qm set "$ID" --scsihw virtio-scsi-pci
+qm set "$ID" --net0 'virtio,bridge=vmbr0'
+qm set "$ID" --scsi0 "$STORAGE:vm-$ID-disk-0,discard=on,ssd=1"
+qm set "$ID" --boot order='scsi0'
 qm set "$ID" --name 'dietpi' >/dev/null
 qm set "$ID" --description '### [DietPi Website](https://dietpi.com/)
 ### [DietPi Docs](https://dietpi.com/docs/)  
-### [DietPi Forum](https://dietpi.com/forum/)
+### [DietPi Forum](https://dietpi.com/forum/)  
 ### [DietPi Blog](https://dietpi.com/blog/)' >/dev/null
 
 # Tell user the virtual machine is created  


### PR DESCRIPTION
Selecting storage type is no longer needed, only the storage location is needed as user input. 
qm commands set in the wrong order would cause the VM to start with the disk unmounted in some circumstances, the two spaces after the code on line 29 i think caused it. 
Now working and fully tested using both thin provisioning and ZFS storage types on Proxmox 8.2.2.
