### PR TITLE
Update dietpi-install.sh

### DIFF
--- a/dietpi-install.sh
+++ b/dietpi-install.sh
@@ -29,15 +29,14 @@ sleep 3
 echo "Importing disk image to storage..."
 qm importdisk "$ID" "$IMAGE_NAME" "$STORAGE"
 
-# Check if the disk was imported correctly
-if ! qm config "$ID" | grep -q "unused0"; then
+# Retrieve the disk path for further usage and print for user
+DISK_PATH=$(qm config "$ID" | awk '/unused0/{print $2;exit}')
+if [[ $DISK_PATH ]]; then
+    echo "Disk path: $DISK_PATH"
+else
     echo "Error: Failed to import disk for VM $ID"
     exit 1
 fi
-
-# Retrieve the disk path and print for user
-DISK_PATH=$(qm config "$ID" | grep "unused0" | awk '{print $2}')
-echo "Disk path: $DISK_PATH"
 
 # Set VM settings
 qm set "$ID" --cores "$CORES"


### PR DESCRIPTION
Fixed the script so the user only needs to enter the storage name. Yes/No question for storage not required. 

Added: `discard=on,ssd=1` for performance.

Removed: Removed question asking the user if they use BTRFS, ZFS or Thin Provisioning.

The script should now work on all storage types, ZFS, BTRFS, TP, Dir etc without the user specifying the type, only the location.

Tested on ZFS, Thin Provisioning and Dir but essentially we have 2 filesystem types, BLOCK and DIR and the script works with.

Let me know if i have missed anything, hopefully this PR is good 👍