### PR TITLE
Set OS type to Linux 2.6+

### DIFF
--- a/dietpi-install.sh
+++ b/dietpi-install.sh
@@ -44,6 +44,7 @@ qm set "$ID" --memory "$RAM"
 qm set "$ID" --scsihw virtio-scsi-pci
 qm set "$ID" --net0 'virtio,bridge=vmbr0'
 qm set "$ID" --scsi0 "$DISK_PATH,discard=on,ssd=1"
+qm set "$ID" --ostype l26
 
 # Verify if the disk was set correctly
 if qm config "$ID" | grep -q "scsi0"; then


### PR DESCRIPTION
Sets the OS type to Linux kernel 2.6+

(no idea how i missed this but better late than never 🤣)

Thinking of also adding `qemu-guest-agent` install but that would require booting the VM immediately. Would this work because DietPi has a setup process on first boot? Curious because maybe it can be added for the user.