### PR TITLE
feat: Add OS version selector menu

### DIFF
--- a/dietpi-install.sh
+++ b/dietpi-install.sh
@@ -14,13 +14,65 @@ cleanup() {
 # Trap Ctrl+C and other interrupts
 trap cleanup INT TERM
 
-# Variables
-IMAGE_URL=$(whiptail --inputbox 'Enter the URL for the DietPi image (default: https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Trixie.qcow2.xz):' 8 78 'https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Trixie.qcow2.xz' --title 'DietPi Installation' 3>&1 1>&2 2>&3)
+# Select DietPi OS Version
+while true; do
+    OS_VERSION=$(whiptail --title "DietPi Installation" --menu "Select DietPi image:" 22 65 13 \
+        "."               "───────── Debian 13 Trixie ─────────" \
+        "trixie"          "Standard (Recommended)" \
+        "trixie-uefi"     "UEFI Boot" \
+        ".."              "───────── Debian 12 Bookworm ───────" \
+        "bookworm"        "Standard" \
+        "bookworm-uefi"   "UEFI Boot" \
+        "..."             "───────── Debian 14 Forky ──────────" \
+        "forky"           "Standard (Testing)" \
+        "forky-uefi"      "UEFI Boot (Testing)" \
+        "...."            "─────────────────────────────────────" \
+        "custom"          "Custom URL" 3>&1 1>&2 2>&3)
 
-# Check if user cancelled
-if [ $? -ne 0 ]; then
-    cleanup
-fi
+    # Check if user cancelled
+    if [ $? -ne 0 ]; then
+        cleanup
+    fi
+
+    # If separator selected, show menu again
+    case "$OS_VERSION" in
+        .|..|...|....) continue ;;
+        *) break ;;
+    esac
+done
+
+# Set IMAGE_URL based on selection
+BASE_URL="https://dietpi.com/downloads/images"
+case $OS_VERSION in
+    trixie)
+        IMAGE_URL="$BASE_URL/DietPi_Proxmox-x86_64-Trixie.qcow2.xz"
+        ;;
+    trixie-uefi)
+        IMAGE_URL="$BASE_URL/DietPi_Proxmox-UEFI-x86_64-Trixie.qcow2.xz"
+        ;;
+    bookworm)
+        IMAGE_URL="$BASE_URL/DietPi_Proxmox-x86_64-Bookworm.qcow2.xz"
+        ;;
+    bookworm-uefi)
+        IMAGE_URL="$BASE_URL/DietPi_Proxmox-UEFI-x86_64-Bookworm.qcow2.xz"
+        ;;
+    forky)
+        IMAGE_URL="$BASE_URL/DietPi_Proxmox-x86_64-Forky.qcow2.xz"
+        ;;
+    forky-uefi)
+        IMAGE_URL="$BASE_URL/DietPi_Proxmox-UEFI-x86_64-Forky.qcow2.xz"
+        ;;
+    custom)
+        IMAGE_URL=$(whiptail --inputbox 'Enter the URL for the DietPi image:' 8 78 "$BASE_URL/DietPi_Proxmox-x86_64-Trixie.qcow2.xz" --title 'DietPi Installation' 3>&1 1>&2 2>&3)
+        if [ $? -ne 0 ]; then
+            cleanup
+        fi
+        ;;
+    *)
+        echo "Invalid selection"
+        cleanup
+        ;;
+esac
 
 RAM=$(whiptail --inputbox 'Enter the amount of RAM (in MB) for the new virtual machine (default: 2048):' 8 78 2048 --title 'DietPi Installation' 3>&1 1>&2 2>&3)
 

--- a/dietpi-install.sh
+++ b/dietpi-install.sh
@@ -16,18 +16,18 @@ trap cleanup INT TERM
 
 # Select DietPi OS Version
 while true; do
-    OS_VERSION=$(whiptail --title "DietPi Installation" --menu "Select DietPi image:" 22 65 13 \
-        "."               "───────── Debian 13 Trixie ─────────" \
-        "trixie"          "Standard (Recommended)" \
-        "trixie-uefi"     "UEFI Boot" \
-        ".."              "───────── Debian 12 Bookworm ───────" \
-        "bookworm"        "Standard" \
-        "bookworm-uefi"   "UEFI Boot" \
-        "..."             "───────── Debian 14 Forky ──────────" \
-        "forky"           "Standard (Testing)" \
-        "forky-uefi"      "UEFI Boot (Testing)" \
-        "...."            "─────────────────────────────────────" \
-        "custom"          "Custom URL" 3>&1 1>&2 2>&3)
+    OS_VERSION=$(whiptail --title 'DietPi Installation' --menu 'Select DietPi image:' 19 65 11 \
+        ''                '───────── Debian 13 Trixie ─────────' \
+        'trixie'          'Standard (Recommended)' \
+        'trixie-uefi'     'UEFI Boot' \
+        ''                '───────── Debian 12 Bookworm ───────' \
+        'bookworm'        'Standard' \
+        'bookworm-uefi'   'UEFI Boot' \
+        ''                '───────── Debian 14 Forky ──────────' \
+        'forky'           'Standard (Testing)' \
+        'forky-uefi'      'UEFI Boot (Testing)' \
+        ''                '────────────────────────────────────' \
+        'custom'          'Custom URL' 3>&1 1>&2 2>&3)
 
     # Check if user cancelled
     if [ $? -ne 0 ]; then
@@ -35,10 +35,9 @@ while true; do
     fi
 
     # If separator selected, show menu again
-    case "$OS_VERSION" in
-        .|..|...|....) continue ;;
-        *) break ;;
-    esac
+    if [ -n "$OS_VERSION" ]; then
+        break
+    fi
 done
 
 # Set IMAGE_URL based on selection


### PR DESCRIPTION
## Summary

Replaces the manual URL input with a user-friendly menu showing all available DietPi Proxmox images:

```
───────── Debian 13 Trixie ─────────
  Standard (Recommended)
  UEFI Boot
───────── Debian 12 Bookworm ───────
  Standard
  UEFI Boot
───────── Debian 14 Forky ──────────
  Standard (Testing)
  UEFI Boot (Testing)
─────────────────────────────────────
  Custom URL
```

## Why?

- **Same number of dialogs** - This replaces the URL input, doesn't add extra steps
- **Less error-prone** - No copy/paste or typos in URLs
- **Beginner-friendly** - Users don't need to know which Debian version or find URLs
- **Power users covered** - "Custom URL" option preserves original behavior
- **All images included** - Standard and UEFI variants for Trixie, Bookworm, and Forky

## Changes

- URL input → menu selector
- Added `BASE_URL` variable for cleaner code
- Visual separators between Debian versions (selecting a separator redisplays the menu)
- All other functionality unchanged (CTRL+C trap, error handling, etc.)